### PR TITLE
Support 2048 DSA key size

### DIFF
--- a/ssh/keys.go
+++ b/ssh/keys.go
@@ -403,7 +403,7 @@ func checkDSAParams(param *dsa.Parameters) error {
 	// SSH specifies FIPS 186-2, which only provided a single size
 	// (1024 bits) DSA key. FIPS 186-3 allows for larger key
 	// sizes, which would confuse SSH.
-	if l := param.P.BitLen(); l != 1024 {
+	if l := param.P.BitLen(); l != 1024 && l != 2048 {
 		return fmt.Errorf("ssh: unsupported DSA key size %d", l)
 	}
 


### PR DESCRIPTION
This is to solve the issue we had when connecting to Svea's SFTP server, which only offers DSA key. 

Reference: 
Related to https://github.com/golang/go/issues/23751